### PR TITLE
Add argument to support setting MessageGroupId for FIFO queues

### DIFF
--- a/src/phoenix_letter/common/arguments.py
+++ b/src/phoenix_letter/common/arguments.py
@@ -63,4 +63,12 @@ def parse_arguments(args):
         metavar="N",
     )
 
+    parser.add_argument(
+        "--group-id",
+        dest="group_id",
+        default=None,
+        help="Value for the MessageGroupId (used in FIFO queues)",
+        metavar="GROUP_ID",
+    )
+
     return parser.parse_args(args)

--- a/src/phoenix_letter/main.py
+++ b/src/phoenix_letter/main.py
@@ -75,16 +75,30 @@ def main(args=None):
         for message in received_response["Messages"]:
             print("Sending message to '{}'".format(args.destination))
 
-            if "MessageAttributes" in message:
-                sqs_client.send_message(
-                    QueueUrl=destination_queue_url,
-                    MessageBody=message["Body"],
-                    MessageAttributes=message["MessageAttributes"],
-                )
+            if args.group_id:
+                if "MessageAttributes" in message:
+                    sqs_client.send_message(
+                        QueueUrl=destination_queue_url,
+                        MessageBody=message["Body"],
+                        MessageAttributes=message["MessageAttributes"],
+                        MessageGroupId=args.group_id,
+                    )
+                else:
+                    sqs_client.send_message(
+                        QueueUrl=destination_queue_url, MessageBody=message["Body"],
+                        MessageGroupId=args.group_id,
+                    )
             else:
-                sqs_client.send_message(
+                if "MessageAttributes" in message:
+                    sqs_client.send_message(
+                        QueueUrl=destination_queue_url,
+                        MessageBody=message["Body"],
+                        MessageAttributes=message["MessageAttributes"],
+                    )
+                else:
+                    sqs_client.send_message(
                     QueueUrl=destination_queue_url, MessageBody=message["Body"]
-                )
+                    )
 
             print("Deleting message from '{}'".format(args.source))
             sqs_client.delete_message(


### PR DESCRIPTION
Added a `--group-id` argument to set the `MessageGroupId` argument when replaying messages to a [FIFO queue](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html)