### PR TITLE
Better support for FIFO queues

### DIFF
--- a/src/phoenix_letter/common/arguments.py
+++ b/src/phoenix_letter/common/arguments.py
@@ -59,8 +59,9 @@ def parse_arguments(args):
         default=10,
         type=int,
         choices=range(1, 11),
-        help="Max number of messages to received from the source queue per request (this will be pass "
-        "in the MaxNumberOfMessages param). Default: 10 (AWS API max limit)",
+        help="Max number of messages to received from the source queue per request "
+             "(this will be pass in the MaxNumberOfMessages param). Default: 10 "
+             "(AWS API max limit)",
         metavar="N",
     )
 
@@ -74,15 +75,13 @@ def parse_arguments(args):
     parser.add_argument(
         "--group-id",
         dest="fifo_group_id",
-        help="Value for the MessageGroupId (used in FIFO queues). Required if '--fifo' argument is passed. Default: NULL. ",
+        help="Override the MessageGroupId (used in FIFO queues). "
+             "Only used if '--fifo' argument is passed. Default: NULL.",
         type=str,
         default=None,
         metavar="MESSAGE_GROUP_ID",
     )
 
     parsed_args = parser.parse_args(args)
-
-    if parsed_args.is_fifo is True and parsed_args.fifo_group_id is None:
-        parser.error("--fifo requires the argument --group-id.")
 
     return parsed_args

--- a/src/phoenix_letter/main.py
+++ b/src/phoenix_letter/main.py
@@ -83,7 +83,15 @@ def main(args=None):
                 message_params["MessageAttributes"] = message["MessageAttributes"]
 
             if args.is_fifo:
-                message_params["MessageGroupId"] = args.fifo_group_id
+                attributes = message.get("Attributes", {})
+                message_group_id = args.fifo_group_id
+                if message_group_id is None:
+                    message_group_id = attributes.get("MessageGroupId")
+
+                message_params["MessageGroupId"] = message_group_id
+
+                if attributes.get("MessageDeduplicationId"):
+                    message_params["MessageDeduplicationId"] = attributes.get("MessageDeduplicationId")
 
             sqs_client.send_message(**message_params)
 


### PR DESCRIPTION
Use the attributes from the message in the source queue when pushing messages into the destination queue, This makes it easier to redrive a FIFO DLQ into the source queue without having to know the individual message deduplication values for every message.